### PR TITLE
Fix build-deps issue with exec rogue-lamb

### DIFF
--- a/rogue-lamb.cabal
+++ b/rogue-lamb.cabal
@@ -15,18 +15,16 @@ extra-source-files: CHANGELOG.md README.md
 
 executable rogue-lamb
     main-is:          Main.hs
-    build-depends:    
-        base ^>=4.14.3.0
-        ,Game
+    build-depends:    base ^>=4.14.3.0,
+                      rogue-lamb
     hs-source-dirs:   app
     default-language: Haskell2010
 
 library
-    hs-source-dirs: src
-    exposed-modules: Game 
-    -- might need more?? base this on https://github.com/adpextwindong/Ozaich/blob/main/Oziach.cabal for now lol
-    build-depends: base ^>=4.14.3.0, ansi-terminal ==0.11, array
+    hs-source-dirs:   src
     default-language: Haskell2010
+    build-depends:    base ^>=4.14.3.0, ansi-terminal == 0.11, array
+    exposed-modules:  Game
 
 source-repository head
     type:   git


### PR DESCRIPTION
You have to refer to the cabal package name not module name.